### PR TITLE
Automate Deploying Static Website - round 2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,6 @@ jobs:
           # setup the username and email. I tend to use 'GitHub Actions Bot' with no email by default
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          git checkout gh-pages
       - name: Setup node 
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Last PR had issues. Specifically, checking out the gh-pages branch before building fails. Now trying to push changes to gh-pages branch by only depending on `git push origin gh-pages` to merge changes from master and the built `docs/` folder to the `gh-pages` branch.