### PR TITLE
ignore .pnpm-store directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ node_modules
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache
+
+# need to ignore .pnpm store on ci-server
+.pnpm-store


### PR DESCRIPTION
Ignore .pnpm-store so docs building workflow can complete successfully